### PR TITLE
Improve Performance of Empty Tree Building

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/yinz",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/yinz",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "A module for injesting a YIN datamodel and handling instance data.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/instance/LeafInstance.ts
+++ b/src/instance/LeafInstance.ts
@@ -6,14 +6,14 @@ import { Leaf } from '../model';
 import { defineNamespaceOnRoot } from '../util/xmlUtil';
 
 import { Searchable, WithAttributes } from './mixins';
-import { Path, Instance, Visitor } from './';
+import { Path, Parent, Visitor, NoMatchHandler } from './';
 
 export type LeafJSON = string | number | boolean;
 
 export default class LeafInstance implements Searchable, WithAttributes {
   public model: Leaf;
   public config: Element;
-  public parent: Instance;
+  public parent: Parent;
   public value: string;
 
   public customAttributes: Map<string, string>;
@@ -22,7 +22,7 @@ export default class LeafInstance implements Searchable, WithAttributes {
   public isMatch: (path: Path) => boolean;
   public handleNoMatch: () => void;
 
-  constructor(model: Leaf, config: Element | LeafJSON, parent?: Instance) {
+  constructor(model: Leaf, config: Element | LeafJSON, parent?: Parent) {
     this.model = model;
     this.parent = parent;
     this.value = null;
@@ -51,12 +51,12 @@ export default class LeafInstance implements Searchable, WithAttributes {
     parent.node(this.model.name, this.value).namespace(prefix);
   }
 
-  public getInstance(path: Path) {
+  public getInstance(path: Path, noMatchHandler: NoMatchHandler = this.handleNoMatch) {
     if (this.isTryingToMatchMe(path) && this.isMatch(path)) {
       return this;
     }
 
-    this.handleNoMatch();
+    noMatchHandler(this, path);
   }
 
   public visit(visitor: Visitor) {

--- a/src/instance/LeafListInstance.ts
+++ b/src/instance/LeafListInstance.ts
@@ -6,13 +6,13 @@ import { LeafList } from '../model';
 import { defineNamespaceOnRoot } from '../util/xmlUtil';
 
 import { Searchable } from './mixins';
-import { Path, Instance, Visitor, LeafListChildInstance, LeafJSON } from './';
+import { Path, Visitor, LeafListChildInstance, LeafJSON, NoMatchHandler, Parent } from './';
 
 export type LeafListJSON = LeafJSON[];
 
 export default class LeafListInstance implements Searchable {
   public model: LeafList;
-  public parent: Instance;
+  public parent: Parent;
   public children: LeafListChildInstance[];
 
   public getPath: () => Path;
@@ -20,7 +20,7 @@ export default class LeafListInstance implements Searchable {
   public isMatch: (path: Path) => boolean;
   public handleNoMatch: () => void;
 
-  constructor(model: LeafList, config: Element | LeafListJSON, parent?: Instance) {
+  constructor(model: LeafList, config: Element | LeafListJSON, parent?: Parent) {
     this.model = model;
     this.parent = parent;
     this.children = [];
@@ -56,12 +56,12 @@ export default class LeafListInstance implements Searchable {
     });
   }
 
-  public getInstance(path: Path) {
+  public getInstance(path: Path, noMatchHandler: NoMatchHandler = this.handleNoMatch) {
     if (this.isTryingToMatchMe(path) && this.isMatch(path)) {
       return this;
     }
 
-    this.handleNoMatch();
+    noMatchHandler(this, path);
   }
 
   public visit(visitor: Visitor) {

--- a/src/instance/ListChildInstance.ts
+++ b/src/instance/ListChildInstance.ts
@@ -16,7 +16,9 @@ import {
   LeafJSON,
   ListJSON,
   LeafListJSON,
-  IContainerJSON
+  IContainerJSON,
+  NoMatchHandler,
+  Parent
 } from './';
 
 export type ChoiceName = string;
@@ -33,7 +35,7 @@ export interface IListChildJSON {
 export default class ListChildInstance implements Searchable, WithAttributes {
   public model: List;
   public config: Element;
-  public parent: Instance;
+  public parent: Parent;
   public instance: Map<ChildName, Instance>;
   public activeChoices: Map<ChoiceName, SelectedCaseName>;
 
@@ -43,7 +45,7 @@ export default class ListChildInstance implements Searchable, WithAttributes {
   public isMatch: (path: Path) => boolean;
   public handleNoMatch: () => void;
 
-  constructor(model: List, config: Element | IListChildJSON, parent: Instance) {
+  constructor(model: List, config: Element | IListChildJSON, parent: Parent) {
     this.model = model;
     this.parent = parent;
     this.instance = new Map();
@@ -137,17 +139,17 @@ export default class ListChildInstance implements Searchable, WithAttributes {
     });
   }
 
-  public getInstance(path: Path): Instance {
+  public getInstance(path: Path, noMatchHandler: NoMatchHandler = this.handleNoMatch): Instance {
     if (path.length === 0) {
       return this;
     } else {
       const nextSegment = _.head(path);
       if (this.instance.has(nextSegment.name)) {
-        return this.instance.get(nextSegment.name).getInstance(path);
+        return this.instance.get(nextSegment.name).getInstance(path, noMatchHandler);
       }
     }
 
-    this.handleNoMatch();
+    noMatchHandler(this, path);
   }
 
   public visit(visitor: Visitor) {

--- a/src/instance/index.ts
+++ b/src/instance/index.ts
@@ -9,6 +9,8 @@ import Instance from './Instance';
 import Path from './Path';
 
 export type Visitor = (instance: Instance | LeafListChildInstance) => void;
+export type NoMatchHandler = (instance: Instance, remainingPath: Path) => any;
+export type Parent = ListChildInstance | ContainerInstance;
 
 export default DataModelInstance;
 

--- a/src/instance/util/__tests__/data/minimalInstance.xml
+++ b/src/instance/util/__tests__/data/minimalInstance.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="afd174a0-5215-11e7-b1ea-6b4fbf1cb918">
-  <data>
-    <t128:config xmlns:t128="http://128technology.com/t128" xmlns:authy="http://128technology.com/t128/config/authority-config" xmlns:svc="http://128technology.com/t128/config/service-config" xmlns:sys="http://128technology.com/t128/config/system-config">
-      <authy:authority>
-        <authy:name>Authority128</authy:name>
-        <authy:router>
-          <authy:name>Fabric128</authy:name>
-          <sys:node>
-            <sys:name>TestNode1</sys:name>
-            <sys:role>combo</sys:role>
-            <sys:enabled>true</sys:enabled>
-          </sys:node>
-        </authy:router>
-      </authy:authority>
-    </t128:config>
-  </data>
-</rpc-reply>
+<t128:config xmlns:t128="http://128technology.com/t128" 
+  xmlns:authy="http://128technology.com/t128/config/authority-config" 
+  xmlns:svc="http://128technology.com/t128/config/service-config" 
+  xmlns:sys="http://128technology.com/t128/config/system-config">
+  <authy:authority>
+    <authy:name>Authority128</authy:name>
+    <authy:router>
+      <authy:name>Fabric128</authy:name>
+      <sys:node>
+        <sys:name>TestNode1</sys:name>
+        <sys:role>combo</sys:role>
+        <sys:enabled>true</sys:enabled>
+      </sys:node>
+    </authy:router>
+  </authy:authority>
+</t128:config>

--- a/src/model/Container.ts
+++ b/src/model/Container.ts
@@ -2,7 +2,7 @@ import { Element } from 'libxmljs';
 import * as _ from 'lodash';
 
 import applyMixins from '../util/applyMixins';
-import { ContainerInstance, Instance, IContainerJSON } from '../instance';
+import { ContainerInstance, Parent, IContainerJSON } from '../instance';
 import { Visibility, Status } from '../enum';
 
 import { PresenceParser } from './parsers';
@@ -79,7 +79,7 @@ export default class Container implements Statement, Whenable, WithRegistry {
     return this.children;
   }
 
-  public buildInstance(config: Element | IContainerJSON, parent?: Instance) {
+  public buildInstance(config: Element | IContainerJSON, parent?: Parent) {
     return new ContainerInstance(this, config, parent);
   }
 

--- a/src/model/Leaf.ts
+++ b/src/model/Leaf.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 
 import applyMixins from '../util/applyMixins';
 import { Visibility, Status } from '../enum';
-import { LeafInstance, Instance, LeafJSON } from '../instance';
+import { LeafInstance, Parent, LeafJSON } from '../instance';
 import { Type, DerivedType, BuiltInType } from '../types';
 
 import { MandatoryParser, DefaultParser } from './parsers';
@@ -65,7 +65,7 @@ export default class Leaf implements Statement, Typed, Whenable, WithIdentities,
     return this.mandatory || this.isKey;
   }
 
-  public buildInstance(config: Element | LeafJSON, parent?: Instance) {
+  public buildInstance(config: Element | LeafJSON, parent?: Parent) {
     return new LeafInstance(this, config, parent);
   }
 

--- a/src/model/LeafList.ts
+++ b/src/model/LeafList.ts
@@ -2,7 +2,7 @@ import { Element } from 'libxmljs';
 
 import applyMixins from '../util/applyMixins';
 import { OrderedBy, Visibility, Status } from '../enum';
-import { LeafListInstance, Instance, LeafListJSON } from '../instance';
+import { LeafListInstance, LeafListJSON, ListChildInstance, ContainerInstance } from '../instance';
 import { Type } from '../types';
 
 import { ListLike, Statement, Typed, Whenable, WithIdentities, WithRegistry, WithUnits } from './mixins';
@@ -56,7 +56,7 @@ export default class LeafList implements ListLike, Statement, Typed, Whenable, W
     this.register(parentModel, this);
   }
 
-  public buildInstance(config: Element | LeafListJSON, parent?: Instance) {
+  public buildInstance(config: Element | LeafListJSON, parent?: ListChildInstance | ContainerInstance) {
     return new LeafListInstance(this, config, parent);
   }
 

--- a/src/model/List.ts
+++ b/src/model/List.ts
@@ -2,7 +2,7 @@ import { Element } from 'libxmljs';
 
 import applyMixins from '../util/applyMixins';
 import ns from '../util/ns';
-import { ListInstance, Instance, ListJSON } from '../instance';
+import { ListInstance, ListJSON, ListChildInstance, ContainerInstance } from '../instance';
 import { OrderedBy, Visibility, Status } from '../enum';
 
 import { Statement, ListLike, Whenable, WithRegistry } from './mixins';
@@ -81,7 +81,7 @@ export default class List implements ListLike, Statement, Whenable, WithRegistry
     return [...this.keys.values()].map(key => this.children.get(key));
   }
 
-  public buildInstance(config: Element | ListJSON, parent?: Instance) {
+  public buildInstance(config: Element | ListJSON, parent?: ListChildInstance | ContainerInstance) {
     return new ListInstance(this, config, parent);
   }
 


### PR DESCRIPTION
* Instead mutate the stored DOM and return a cleanup handler.
* Remove XPath for context node finder and use in memory lookup instead.