### PR TITLE
shouldSkip function parameter in toJSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/yinz",
-  "version": "4.2.9",
+  "version": "4.2.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/yinz",
-  "version": "4.2.9",
+  "version": "4.2.10",
   "description": "A module for injesting a YIN datamodel and handling instance data.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/instance/ContainerInstance.ts
+++ b/src/instance/ContainerInstance.ts
@@ -16,7 +16,8 @@ import {
   LeafListJSON,
   ListJSON,
   NoMatchHandler,
-  Parent
+  Parent,
+  ShouldSkip
 } from './';
 
 export interface IContainerJSON {
@@ -50,7 +51,7 @@ export default class ContainerInstance implements Searchable, WithAttributes {
     }
   }
 
-  public toJSON(camelCase = false, convert = true, shouldSkip = (ins: Instance) => false): IContainerJSON {
+  public toJSON(camelCase = false, convert = true, shouldSkip?: ShouldSkip): IContainerJSON {
     const containerInner = [...this.children.values()].reduce(
       (acc, child) => Object.assign(acc, child.toJSON(camelCase, convert, shouldSkip)),
       {}

--- a/src/instance/ContainerInstance.ts
+++ b/src/instance/ContainerInstance.ts
@@ -50,9 +50,9 @@ export default class ContainerInstance implements Searchable, WithAttributes {
     }
   }
 
-  public toJSON(camelCase = false, convert = true): IContainerJSON {
+  public toJSON(camelCase = false, convert = true, shouldSkip = (ins: Instance) => false): IContainerJSON {
     const containerInner = [...this.children.values()].reduce(
-      (acc, child) => Object.assign(acc, child.toJSON(camelCase, convert)),
+      (acc, child) => Object.assign(acc, child.toJSON(camelCase, convert, shouldSkip)),
       {}
     );
 

--- a/src/instance/DataModelInstance.ts
+++ b/src/instance/DataModelInstance.ts
@@ -60,8 +60,8 @@ export default class DataModelInstance {
     }
   }
 
-  public toJSON(camelCase = false, convert = true): object {
-    return [...this.root.values()][0].toJSON(camelCase, convert);
+  public toJSON(camelCase = false, convert = true, shouldSkip = (ins: Instance) => false): object {
+    return [...this.root.values()][0].toJSON(camelCase, convert, shouldSkip);
   }
 
   public toXML(rootEl?: Element) {

--- a/src/instance/DataModelInstance.ts
+++ b/src/instance/DataModelInstance.ts
@@ -17,7 +17,8 @@ import {
   ListChildInstance,
   NoMatchHandler,
   ListInstance,
-  LeafListInstance
+  LeafListInstance,
+  ShouldSkip
 } from './';
 import {
   getPathXPath,
@@ -60,7 +61,7 @@ export default class DataModelInstance {
     }
   }
 
-  public toJSON(camelCase = false, convert = true, shouldSkip = (ins: Instance) => false): object {
+  public toJSON(camelCase = false, convert = true, shouldSkip?: ShouldSkip): object {
     return [...this.root.values()][0].toJSON(camelCase, convert, shouldSkip);
   }
 

--- a/src/instance/ListChildInstance.ts
+++ b/src/instance/ListChildInstance.ts
@@ -125,9 +125,13 @@ export default class ListChildInstance implements Searchable, WithAttributes {
       });
   }
 
-  public toJSON(camelCase = false, convert = true): IListChildJSON {
+  public toJSON(camelCase = false, convert = true, shouldSkip = (ins: Instance) => false): IListChildJSON {
     return [...this.instance.values()]
-      .map(field => field.toJSON(camelCase, convert))
+      .map(field =>
+        field instanceof LeafInstance || field instanceof LeafListInstance
+          ? field.toJSON(camelCase, convert)
+          : field.toJSON(camelCase, convert, shouldSkip)
+      )
       .reduce((acc, field) => Object.assign(acc, field), {});
   }
 

--- a/src/instance/ListChildInstance.ts
+++ b/src/instance/ListChildInstance.ts
@@ -18,7 +18,8 @@ import {
   LeafListJSON,
   IContainerJSON,
   NoMatchHandler,
-  Parent
+  Parent,
+  ShouldSkip
 } from './';
 
 export type ChoiceName = string;
@@ -125,7 +126,7 @@ export default class ListChildInstance implements Searchable, WithAttributes {
       });
   }
 
-  public toJSON(camelCase = false, convert = true, shouldSkip = (ins: Instance) => false): IListChildJSON {
+  public toJSON(camelCase = false, convert = true, shouldSkip?: ShouldSkip): IListChildJSON {
     return [...this.instance.values()]
       .map(field =>
         field instanceof LeafInstance || field instanceof LeafListInstance

--- a/src/instance/ListInstance.ts
+++ b/src/instance/ListInstance.ts
@@ -63,11 +63,13 @@ export default class ListInstance implements Searchable {
           value.push(child.toJSON(camelCase, convert));
         }
       }
+    } else {
+      for (const child of this.children.values()) {
+        value.push(child.toJSON(camelCase, convert));
+      }
     }
     return {
-      [this.model.getName(camelCase)]: shouldSkip
-        ? value
-        : [...this.children.values()].map(child => child.toJSON(camelCase, convert))
+      [this.model.getName(camelCase)]: value
     };
   }
 

--- a/src/instance/ListInstance.ts
+++ b/src/instance/ListInstance.ts
@@ -5,7 +5,7 @@ import applyMixins from '../util/applyMixins';
 import { List } from '../model';
 
 import { Searchable } from './mixins';
-import { Path, ListChildInstance, IListChildJSON, LeafInstance, Visitor, NoMatchHandler, Parent } from './';
+import { Path, ListChildInstance, IListChildJSON, LeafInstance, Visitor, NoMatchHandler, Parent, Instance } from './';
 import { isKeyedSegment } from './Path';
 
 // Comma separated string of key values
@@ -55,9 +55,19 @@ export default class ListInstance implements Searchable {
     this.children.set(keys, newChild);
   }
 
-  public toJSON(camelCase = false, convert = true): { [name: string]: ListJSON } {
+  public toJSON(
+    camelCase = false,
+    convert = true,
+    shouldSkip = (ins: Instance) => false
+  ): { [name: string]: ListJSON } {
+    const value = [];
+    for (const child of this.children.values()) {
+      if (!shouldSkip(child)) {
+        value.push(child.toJSON(camelCase, convert));
+      }
+    }
     return {
-      [this.model.getName(camelCase)]: [...this.children.values()].map(child => child.toJSON(camelCase, convert))
+      [this.model.getName(camelCase)]: value
     };
   }
 

--- a/src/instance/ListInstance.ts
+++ b/src/instance/ListInstance.ts
@@ -5,7 +5,7 @@ import applyMixins from '../util/applyMixins';
 import { List } from '../model';
 
 import { Searchable } from './mixins';
-import { Path, ListChildInstance, IListChildJSON, LeafInstance, Visitor, NoMatchHandler, Parent, Instance } from './';
+import { Path, ListChildInstance, IListChildJSON, LeafInstance, Visitor, NoMatchHandler, Parent, ShouldSkip } from './';
 import { isKeyedSegment } from './Path';
 
 // Comma separated string of key values
@@ -55,19 +55,19 @@ export default class ListInstance implements Searchable {
     this.children.set(keys, newChild);
   }
 
-  public toJSON(
-    camelCase = false,
-    convert = true,
-    shouldSkip = (ins: Instance) => false
-  ): { [name: string]: ListJSON } {
+  public toJSON(camelCase = false, convert = true, shouldSkip?: ShouldSkip): { [name: string]: ListJSON } {
     const value = [];
-    for (const child of this.children.values()) {
-      if (!shouldSkip(child)) {
-        value.push(child.toJSON(camelCase, convert));
+    if (shouldSkip) {
+      for (const child of this.children.values()) {
+        if (!shouldSkip(child)) {
+          value.push(child.toJSON(camelCase, convert));
+        }
       }
     }
     return {
-      [this.model.getName(camelCase)]: value
+      [this.model.getName(camelCase)]: shouldSkip
+        ? value
+        : [...this.children.values()].map(child => child.toJSON(camelCase, convert))
     };
   }
 

--- a/src/instance/__tests__/DataModelInstance-test.ts
+++ b/src/instance/__tests__/DataModelInstance-test.ts
@@ -83,6 +83,24 @@ describe('Data Model Instance', () => {
       expect(dataModelInstance.toJSON(true, false)).to.deep.equal(instanceNotConverted);
     });
 
+    it('should serialize an instance to JSON without skipped fields', () => {
+      const instanceSkippedFields = readJSON('./data/instanceSkippedFields.json');
+      expect(
+        dataModelInstance.toJSON(
+          true,
+          false,
+          x => x instanceof ListChildInstance && x.instance && x.instance.has('bfd')
+        )
+      ).to.deep.equal(instanceSkippedFields);
+    });
+
+    it('should serialize an instance to JSON and not skip LeafInstance or LeafListInstance or ', () => {
+      const instanceNotConverted = readJSON('./data/instanceNotConverted.json');
+      expect(
+        dataModelInstance.toJSON(true, false, x => x instanceof LeafInstance || x instanceof LeafListInstance)
+      ).to.deep.equal(instanceNotConverted);
+    });
+
     it('should serialize an instance to XML', () => {
       const expectedXML = readConfigFile('./data/instanceToXML.xml');
       expect(dataModelInstance.toXML().toString()).xml.to.equal(expectedXML.toString());

--- a/src/instance/__tests__/ListInstance-test.ts
+++ b/src/instance/__tests__/ListInstance-test.ts
@@ -52,6 +52,14 @@ describe('List Instance', () => {
     });
   });
 
+  it('should serialize to JSON without skipped fields', () => {
+    const instance = new ListInstance(listModel, mockConfigXML);
+
+    expect(instance.toJSON(false, true, ins => ins instanceof ListChildInstance)).to.deep.equal({
+      peer: []
+    });
+  });
+
   it('should serialize to XML', () => {
     const instance = new ListInstance(listModel, mockConfigXML);
 

--- a/src/instance/__tests__/data/instanceSkippedFields.json
+++ b/src/instance/__tests__/data/instanceSkippedFields.json
@@ -1,0 +1,411 @@
+{
+  "authority": {
+    "name": "Authority128",
+    "sessionType": [
+      {
+        "name": "HTTP",
+        "serviceClass": "Standard",
+        "transport": [
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "80"
+              },
+              {
+                "startPort": "8080"
+              }
+            ]
+          }
+        ],
+        "timeout": "1900000"
+      },
+      {
+        "name": "HTTPS",
+        "serviceClass": "Standard",
+        "transport": [
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "443"
+              }
+            ]
+          }
+        ],
+        "timeout": "1900000"
+      },
+      {
+        "name": "FTP",
+        "serviceClass": "HighThroughputData",
+        "transport": [
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "20",
+                "endPort": "21"
+              }
+            ]
+          }
+        ],
+        "timeout": "1900000"
+      },
+      {
+        "name": "SSH",
+        "serviceClass": "OAM",
+        "transport": [
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "22"
+              }
+            ]
+          }
+        ],
+        "timeout": "1900000"
+      },
+      {
+        "name": "Telnet",
+        "serviceClass": "OAM",
+        "transport": [
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "23"
+              }
+            ]
+          }
+        ],
+        "timeout": "1900000"
+      },
+      {
+        "name": "SMTP",
+        "serviceClass": "HighThroughputData",
+        "transport": [
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "25"
+              }
+            ]
+          }
+        ],
+        "timeout": "10000"
+      },
+      {
+        "name": "DNS",
+        "serviceClass": "NetworkControl",
+        "transport": [
+          {
+            "protocol": "udp",
+            "portRange": [
+              {
+                "startPort": "53"
+              }
+            ]
+          }
+        ],
+        "timeout": "5000"
+      },
+      {
+        "name": "RTP",
+        "serviceClass": "MultimediaStreaming",
+        "transport": [
+          {
+            "protocol": "udp",
+            "portRange": [
+              {
+                "startPort": "5004",
+                "endPort": "5005"
+              }
+            ]
+          }
+        ],
+        "timeout": "180000"
+      },
+      {
+        "name": "SIP",
+        "serviceClass": "Telephony",
+        "transport": [
+          {
+            "protocol": "udp",
+            "portRange": [
+              {
+                "startPort": "5060"
+              }
+            ]
+          },
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "5060"
+              }
+            ]
+          }
+        ],
+        "timeout": "3600000"
+      },
+      {
+        "name": "SIPS",
+        "serviceClass": "Telephony",
+        "transport": [
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "5061"
+              }
+            ]
+          }
+        ],
+        "timeout": "3600000"
+      },
+      {
+        "name": "TFTP",
+        "serviceClass": "HighThroughputData",
+        "transport": [
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "69"
+              }
+            ]
+          }
+        ],
+        "timeout": "1900000"
+      },
+      {
+        "name": "SFTP",
+        "serviceClass": "HighThroughputData",
+        "transport": [
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "989",
+                "endPort": "990"
+              }
+            ]
+          }
+        ],
+        "timeout": "1900000"
+      },
+      {
+        "name": "POP3",
+        "serviceClass": "HighThroughputData",
+        "transport": [
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "110"
+              },
+              {
+                "startPort": "995"
+              }
+            ]
+          }
+        ],
+        "timeout": "10000"
+      },
+      {
+        "name": "SNMP",
+        "serviceClass": "OAM",
+        "transport": [
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "161",
+                "endPort": "162"
+              }
+            ]
+          }
+        ],
+        "timeout": "10000"
+      },
+      {
+        "name": "BGP",
+        "serviceClass": "NetworkControl",
+        "transport": [
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "179"
+              }
+            ]
+          }
+        ],
+        "timeout": "1900000"
+      },
+      {
+        "name": "IPSEC",
+        "serviceClass": "Standard",
+        "transport": [
+          {
+            "protocol": "udp",
+            "portRange": [
+              {
+                "startPort": "1293"
+              }
+            ]
+          },
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "1293"
+              }
+            ]
+          }
+        ],
+        "timeout": "1900000"
+      },
+      {
+        "name": "IPSEC-NAT",
+        "serviceClass": "Standard",
+        "transport": [
+          {
+            "protocol": "udp",
+            "portRange": [
+              {
+                "startPort": "4500"
+              }
+            ]
+          },
+          {
+            "protocol": "tcp",
+            "portRange": [
+              {
+                "startPort": "4500"
+              }
+            ]
+          }
+        ],
+        "timeout": "1900000"
+      }
+    ],
+    "serviceClass": [
+      {
+        "name": "Standard",
+        "priority": "0",
+        "dscp": "0",
+        "rateLimit": "false",
+        "maxFlowRate": "0",
+        "maxFlowBurst": "0"
+      },
+      {
+        "name": "NetworkControl",
+        "priority": "0",
+        "dscp": "48",
+        "rateLimit": "false",
+        "maxFlowRate": "0",
+        "maxFlowBurst": "0"
+      },
+      {
+        "name": "Telephony",
+        "priority": "0",
+        "dscp": "46",
+        "rateLimit": "false",
+        "maxFlowRate": "0",
+        "maxFlowBurst": "0"
+      },
+      {
+        "name": "Signalling",
+        "priority": "0",
+        "dscp": "40",
+        "rateLimit": "false",
+        "maxFlowRate": "0",
+        "maxFlowBurst": "0"
+      },
+      {
+        "name": "MultimediaConferencing",
+        "priority": "0",
+        "dscp": "34",
+        "rateLimit": "false",
+        "maxFlowRate": "0",
+        "maxFlowBurst": "0"
+      },
+      {
+        "name": "RealTimeInteractive",
+        "priority": "0",
+        "dscp": "32",
+        "rateLimit": "false",
+        "maxFlowRate": "0",
+        "maxFlowBurst": "0"
+      },
+      {
+        "name": "MultimediaStreaming",
+        "priority": "0",
+        "dscp": "26",
+        "rateLimit": "false",
+        "maxFlowRate": "0",
+        "maxFlowBurst": "0"
+      },
+      {
+        "name": "BroadcastVideo",
+        "priority": "0",
+        "dscp": "24",
+        "rateLimit": "false",
+        "maxFlowRate": "0",
+        "maxFlowBurst": "0"
+      },
+      {
+        "name": "LowLatencyData",
+        "priority": "0",
+        "dscp": "18",
+        "rateLimit": "false",
+        "maxFlowRate": "0",
+        "maxFlowBurst": "0"
+      },
+      {
+        "name": "OAM",
+        "priority": "0",
+        "dscp": "16",
+        "rateLimit": "false",
+        "maxFlowRate": "0",
+        "maxFlowBurst": "0"
+      },
+      {
+        "name": "HighThroughputData",
+        "priority": "0",
+        "dscp": "10",
+        "rateLimit": "false",
+        "maxFlowRate": "0",
+        "maxFlowBurst": "0"
+      },
+      {
+        "name": "LowPriorityData",
+        "priority": "0",
+        "dscp": "8",
+        "rateLimit": "false",
+        "maxFlowRate": "0",
+        "maxFlowBurst": "0"
+      }
+    ],
+    "security": [
+      {
+        "name": "internal",
+        "description": "inter-node security",
+        "encryptionCipher": "aes-cbc-256",
+        "encryptionKey": "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
+        "encryptionIv": "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+        "encrypt": "true",
+        "hmac": "true",
+        "hmacCipher": "sha256-128",
+        "hmacKey": "4a656665",
+        "adaptiveEncryption": "true"
+      }
+    ],
+    "router": [
+    ],
+    "rekeyInterval": "never"
+  }
+}

--- a/src/instance/index.ts
+++ b/src/instance/index.ts
@@ -11,6 +11,7 @@ import Path from './Path';
 export type Visitor = (instance: Instance | LeafListChildInstance) => void;
 export type NoMatchHandler = (instance: Instance, remainingPath: Path) => any;
 export type Parent = ListChildInstance | ContainerInstance;
+export type ShouldSkip = (instance: Instance) => boolean;
 
 export default DataModelInstance;
 


### PR DESCRIPTION
Added a function parameter that allows you to specify when to skip json-ifying a child Instance when calling toJSON on a DataModelInstance