### PR TITLE
Updated ListInstance to pass shouldSkip param.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/yinz",
-  "version": "4.2.12",
+  "version": "4.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/yinz",
-  "version": "4.2.12",
+  "version": "4.2.13",
   "description": "A module for injesting a YIN datamodel and handling instance data.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/instance/ListInstance.ts
+++ b/src/instance/ListInstance.ts
@@ -60,7 +60,7 @@ export default class ListInstance implements Searchable {
     if (shouldSkip) {
       for (const child of this.children.values()) {
         if (!shouldSkip(child)) {
-          value.push(child.toJSON(camelCase, convert));
+          value.push(child.toJSON(camelCase, convert, shouldSkip));
         }
       }
     } else {

--- a/src/instance/__tests__/DataModelInstance-test.ts
+++ b/src/instance/__tests__/DataModelInstance-test.ts
@@ -86,15 +86,11 @@ describe('Data Model Instance', () => {
     it('should serialize an instance to JSON without skipped fields', () => {
       const instanceSkippedFields = readJSON('./data/instanceSkippedFields.json');
       expect(
-        dataModelInstance.toJSON(
-          true,
-          false,
-          x => x instanceof ListChildInstance && x.instance && x.instance.has('bfd')
-        )
+        dataModelInstance.toJSON(true, false, x => x instanceof ListChildInstance && x.model.name === 'node')
       ).to.deep.equal(instanceSkippedFields);
     });
 
-    it('should serialize an instance to JSON and not skip LeafInstance or LeafListInstance or ', () => {
+    it('should serialize an instance to JSON and not skip LeafInstance or LeafListInstance', () => {
       const instanceNotConverted = readJSON('./data/instanceNotConverted.json');
       expect(
         dataModelInstance.toJSON(true, false, x => x instanceof LeafInstance || x instanceof LeafListInstance)

--- a/src/instance/__tests__/data/instanceSkippedFields.json
+++ b/src/instance/__tests__/data/instanceSkippedFields.json
@@ -405,6 +405,85 @@
       }
     ],
     "router": [
+      {
+        "name": "Fabric128",
+        "interNodeSecurity": "internal",
+        "group": ["group1", "group2"],
+        "node": [],
+        "id": "00000000-0000-0000-0000-000000000000",
+        "system": {
+          "services": {
+            "webserver": {
+              "server": [
+                {
+                  "nodeName": "TestNode2",
+                  "ipAddress": "0.0.0.0"
+                }
+              ],
+              "enabled": "true",
+              "port": "443",
+              "ipAddress": "127.0.0.1"
+            },
+            "epm": {
+              "ipAddress": "127.0.0.1",
+              "port": "14444"
+            },
+            "pdm": {
+              "ipAddress": "127.0.0.1",
+              "port": "830"
+            },
+            "routingEngineListener": {
+              "port": "2620"
+            },
+            "routingAgentListener": {
+              "ipAddress": "127.0.0.1",
+              "port": "13333"
+            },
+            "systemServicesCoordinator": {
+              "ipAddress": "127.0.0.1",
+              "port": "12222"
+            },
+            "runtimeDataStore": {
+              "ipAddress": "127.0.0.1",
+              "port": "6379"
+            }
+          },
+          "logLevel": "trace",
+          "inactivityTimer": "900",
+          "syslog": {
+            "severity": "info",
+            "facility": "local0"
+          },
+          "metrics": {
+            "samplePeriod": "5"
+          },
+          "audit": {
+            "traffic": {
+              "enabled": "false"
+            },
+            "administration": {
+              "enabled": "false"
+            },
+            "system": {
+              "enabled": "false"
+            }
+          }
+        },
+        "reverseFlowEnforcement": "none",
+        "bfd": {
+          "state": "enabled",
+          "desiredTxInterval": "1000",
+          "requiredMinRxInterval": "500",
+          "requiredMinEchoInterval": "1000",
+          "authenticationType": "sha256",
+          "multiplier": "3",
+          "linkTestInterval": "10",
+          "linkTestLength": "20"
+        },
+        "entitlement": {
+          "maxBandwidth": "0"
+        }
+      }
     ],
     "rekeyInterval": "never"
   }


### PR DESCRIPTION
toJSON implementation for shouldSkip would not pass shouldSkip value down recursively, so only the top level ListInstance would check if the field should be skipped, and any nested instances that would use this check would hit a case where shouldSkip was not defined, leading to nested values not being omitted properly.
Updated the test case to skip nested values and check if they were skipped properly.