### PR TITLE
Update unauthorized returns

### DIFF
--- a/src/instance/ContainerInstance.ts
+++ b/src/instance/ContainerInstance.ts
@@ -103,14 +103,16 @@ export default class ContainerInstance implements Searchable, WithAttributes {
     convert = true,
     shouldSkip?: ShouldSkip
   ): ContainerJSONValue {
-    const containerInner = [...this.children.values()].reduce(
-      (acc, child) => Object.assign(acc, child.toJSON(authorized, camelCase, convert, shouldSkip)),
-      {}
-    );
+    const containerInner = [...this.children.values()].reduce((acc, child) => {
+      const childJSON = child.toJSON(authorized, camelCase, convert, shouldSkip);
+      return _.isEmpty(childJSON) ? acc : Object.assign(acc, childJSON);
+    }, {});
 
-    return {
-      [this.model.getName(camelCase)]: containerInner
-    };
+    return _.isEmpty(containerInner)
+      ? {}
+      : {
+          [this.model.getName(camelCase)]: containerInner
+        };
   }
 
   public mapToJSON(

--- a/src/instance/ContainerInstance.ts
+++ b/src/instance/ContainerInstance.ts
@@ -103,16 +103,18 @@ export default class ContainerInstance implements Searchable, WithAttributes {
     convert = true,
     shouldSkip?: ShouldSkip
   ): ContainerJSONValue {
-    const containerInner = [...this.children.values()].reduce((acc, child) => {
-      const childJSON = child.toJSON(authorized, camelCase, convert, shouldSkip);
-      return _.isEmpty(childJSON) ? acc : Object.assign(acc, childJSON);
-    }, {});
+    if (!authorized(this)) {
+      return {};
+    }
 
-    return _.isEmpty(containerInner)
-      ? {}
-      : {
-          [this.model.getName(camelCase)]: containerInner
-        };
+    const containerInner = [...this.children.values()].reduce(
+      (acc, child) => Object.assign(acc, child.toJSON(authorized, camelCase, convert, shouldSkip)),
+      {}
+    );
+
+    return {
+      [this.model.getName(camelCase)]: containerInner
+    };
   }
 
   public mapToJSON(

--- a/src/instance/LeafInstance.ts
+++ b/src/instance/LeafInstance.ts
@@ -81,6 +81,10 @@ export default class LeafInstance implements Searchable, WithAttributes {
   }
 
   public toJSON(authorized: Authorized, camelCase = false, convert = true): { [name: string]: LeafJSONValue } {
+    if (!authorized(this)) {
+      return {};
+    }
+
     return {
       [this.model.getName(camelCase)]: convert ? this.getConvertedValue(authorized) : this.getValue(authorized)
     };

--- a/src/instance/LeafListInstance.ts
+++ b/src/instance/LeafListInstance.ts
@@ -65,6 +65,10 @@ export default class LeafListInstance implements Searchable {
   }
 
   public toJSON(authorized: Authorized, camelCase = false, convert = true): { [name: string]: LeafListJSONValue } {
+    if (!authorized(this)) {
+      return {};
+    }
+
     return {
       [this.model.getName(camelCase)]: convert ? this.getValues(authorized) : this.getRawValues(authorized)
     };

--- a/src/instance/ListChildInstance.ts
+++ b/src/instance/ListChildInstance.ts
@@ -198,6 +198,7 @@ export default class ListChildInstance implements Searchable, WithAttributes {
           ? field.toJSON(authorized, camelCase, convert)
           : field.toJSON(authorized, camelCase, convert, shouldSkip)
       )
+      .filter(item => !_.isEmpty(item))
       .reduce((acc, field) => Object.assign(acc, field), {});
   }
 

--- a/src/instance/ListInstance.ts
+++ b/src/instance/ListInstance.ts
@@ -99,9 +99,8 @@ export default class ListInstance implements Searchable {
         value.push(child.toJSON(authorized, camelCase, convert));
       }
     }
-    return {
-      [this.model.getName(camelCase)]: value
-    };
+    const returnVal = value.filter(item => !_.isEmpty(item));
+    return _.isEmpty(returnVal) ? {} : { [this.model.getName(camelCase)]: returnVal };
   }
 
   public mapToJSON(

--- a/src/instance/__tests__/Authorization-test.ts
+++ b/src/instance/__tests__/Authorization-test.ts
@@ -80,6 +80,6 @@ describe('Authorization Test', () => {
   });
 
   it('should return empty object when not authorized', () => {
-    expect(dataModelInstance.toJSON(() => false)).to.deep.equal({ authority: {} });
+    expect(dataModelInstance.toJSON(() => false)).to.deep.equal({});
   });
 });

--- a/src/instance/__tests__/Authorization-test.ts
+++ b/src/instance/__tests__/Authorization-test.ts
@@ -8,9 +8,10 @@ import _ = require('lodash');
 
 function accessToRouter(routerName: string) {
   return (i: any) => {
+    const instancePath = i.getPath();
     return (
-      i.getPath().filter((v: any) => _.isEqual(v, { name: 'router', keys: [{ key: 'name', value: routerName }] }))
-        .length > 0
+      instancePath.filter((v: any) => _.isEqual(v, { name: 'router', keys: [{ key: 'name', value: routerName }] }))
+        .length > 0 || _.isEqual(instancePath, [{ name: 'authority' }])
     );
   };
 }

--- a/src/instance/__tests__/Authorization-test.ts
+++ b/src/instance/__tests__/Authorization-test.ts
@@ -1,0 +1,85 @@
+import DataModelInstance from '..';
+import * as fs from 'fs';
+import { readDataModel } from './DataModelInstance-test';
+import { expect } from 'chai';
+import * as path from 'path';
+import xmlUtil from '../../__tests__/xmlUtil';
+import _ = require('lodash');
+
+function accessToRouter(routerName: string) {
+  return (i: any) => {
+    return (
+      i.getPath().filter((v: any) => _.isEqual(v, { name: 'router', keys: [{ key: 'name', value: routerName }] }))
+        .length > 0
+    );
+  };
+}
+
+const userModel = readDataModel('../../model/__tests__/data/consolidatedUserModel.xml');
+
+describe('Authorization Test', () => {
+  const instanceRawJSON = JSON.parse(fs.readFileSync(path.join(__dirname, './data/userAuthInstance.json'), 'utf8'));
+  const instance = xmlUtil.toElement(fs.readFileSync(path.join(__dirname, './data/userAuthInstance.xml'), 'utf8'));
+  const config = instance.get('//user:config', { user: 'http://128technology.com/user' })!;
+  let dataModelInstance: DataModelInstance;
+
+  beforeEach(() => {
+    dataModelInstance = new DataModelInstance(userModel, config);
+  });
+
+  it('should be constructable from JSON', () => {
+    expect(dataModelInstance.toJSON(() => true)).to.deep.equal(instanceRawJSON);
+  });
+
+  it('should restrict return value based on authorization', () => {
+    const result = {
+      authority: {
+        router: [
+          {
+            name: 'Fabric128',
+            user: [
+              {
+                enabled: true,
+                name: 'admin',
+                password: '(removed)',
+                role: ['admin']
+              }
+            ]
+          }
+        ]
+      }
+    };
+
+    expect(dataModelInstance.toJSON(accessToRouter('Fabric128'))).to.deep.equal(result);
+
+    const resultBase = {
+      authority: {
+        router: [
+          {
+            name: 'BasicFabric128',
+            user: [
+              {
+                name: 'admin',
+                password: '(removed)',
+                role: ['admin'],
+                enabled: true
+              },
+              {
+                name: 'baseUser',
+                password: '(removed)',
+                role: ['user'],
+                enabled: true
+              }
+            ]
+          }
+        ]
+      }
+    };
+
+    expect(dataModelInstance.toJSON(accessToRouter('BasicFabric128'))).to.deep.equal(resultBase);
+  });
+
+  it('should return empty object when not authorized', () => {
+    expect(dataModelInstance.toJSON(() => false)).to.deep.equal({ authority: {} });
+  });
+});

--- a/src/instance/__tests__/ContainerInstance-test.ts
+++ b/src/instance/__tests__/ContainerInstance-test.ts
@@ -59,7 +59,9 @@ describe('Container Instance', () => {
   it('should delete a child that exists', () => {
     const instance = new ContainerInstance(leafModel, mockConfigXML, null);
     instance.delete('state');
-    expect(instance.toJSON(allow)).to.deep.equal({});
+    expect(instance.toJSON(allow)).to.deep.equal({
+      bfd: {}
+    });
   });
 
   it('should throw if child does not exist', () => {

--- a/src/instance/__tests__/ContainerInstance-test.ts
+++ b/src/instance/__tests__/ContainerInstance-test.ts
@@ -59,9 +59,7 @@ describe('Container Instance', () => {
   it('should delete a child that exists', () => {
     const instance = new ContainerInstance(leafModel, mockConfigXML, null);
     instance.delete('state');
-    expect(instance.toJSON(allow)).to.deep.equal({
-      bfd: {}
-    });
+    expect(instance.toJSON(allow)).to.deep.equal({});
   });
 
   it('should throw if child does not exist', () => {

--- a/src/instance/__tests__/ListInstance-test.ts
+++ b/src/instance/__tests__/ListInstance-test.ts
@@ -55,9 +55,7 @@ describe('List Instance', () => {
   it('should serialize to JSON without skipped fields', () => {
     const instance = new ListInstance(listModel, mockConfigXML, {} as ContainerInstance);
 
-    expect(instance.toJSON(allow, false, true, ins => ins instanceof ListChildInstance)).to.deep.equal({
-      peer: []
-    });
+    expect(instance.toJSON(allow, false, true, ins => ins instanceof ListChildInstance)).to.deep.equal({});
   });
 
   it('should serialize to XML', () => {

--- a/src/instance/__tests__/data/instanceSkippedFields.json
+++ b/src/instance/__tests__/data/instanceSkippedFields.json
@@ -409,7 +409,6 @@
         "name": "Fabric128",
         "interNodeSecurity": "internal",
         "group": ["group1", "group2"],
-        "node": [],
         "id": "00000000-0000-0000-0000-000000000000",
         "system": {
           "services": {

--- a/src/instance/__tests__/data/userAuthInstance.json
+++ b/src/instance/__tests__/data/userAuthInstance.json
@@ -1,0 +1,68 @@
+{
+  "authority": {
+    "name": "Authority128",
+    "role": [
+      {
+        "name": "admin",
+        "rule": [
+          "admin-configure"
+        ]
+      },
+      {
+        "name": "user",
+        "rule": [
+          "user-show"
+        ]
+      }
+    ],
+    "rule": [
+      {
+        "name": "admin-configure",
+        "access": "allow",
+        "features": "configure"
+      },
+      {
+        "name": "user-show",
+        "access": "allow",
+        "features": "show-commands"
+      }
+    ],
+    "router": [
+      {
+        "name": "Fabric128",
+        "user": [
+          {
+            "name": "admin",
+            "password": "(removed)",
+            "role": [
+              "admin"
+            ],
+            "enabled": true
+          }
+        ]
+      },
+      {
+        "name": "BasicFabric128",
+        "user": [
+          {
+            "name": "admin",
+            "password": "(removed)",
+            "role": [
+              "admin"
+            ],
+            "enabled": true
+          },
+          {
+            "name": "baseUser",
+            "password": "(removed)",
+            "role": [
+              "user"
+            ],
+            "enabled": true
+          }
+        ]
+      }
+    ],
+    "mode": "moderate"
+  }
+}

--- a/src/instance/__tests__/data/userAuthInstance.xml
+++ b/src/instance/__tests__/data/userAuthInstance.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="124">
+    <data>
+        <user:config xmlns:user="http://128technology.com/user">
+            <user:authority>
+                <user:name>Authority128</user:name>
+                <user:role>
+                    <user:name>admin</user:name>
+                    <user:rule>admin-configure</user:rule>
+                </user:role>
+                <user:role>
+                    <user:name>user</user:name>
+                    <user:rule>user-show</user:rule>
+                </user:role>
+                <user:rule>
+                    <user:name>admin-configure</user:name>
+                    <user:access>allow</user:access>
+                    <user:features>configure</user:features>
+                </user:rule>
+                <user:rule>
+                    <user:name>user-show</user:name>
+                    <user:access>allow</user:access>
+                    <user:features>show-commands</user:features>
+                </user:rule>
+                <user:router>
+                    <user:name>Fabric128</user:name>
+                    <user:user>
+                        <user:name>admin</user:name>
+                        <user:password>(removed)</user:password>
+                        <user:role>admin</user:role>
+                        <user:enabled>true</user:enabled>
+                    </user:user>
+                </user:router>
+                <user:router>
+                    <user:name>BasicFabric128</user:name>
+                    <user:user>
+                        <user:name>admin</user:name>
+                        <user:password>(removed)</user:password>
+                        <user:role>admin</user:role>
+                        <user:enabled>true</user:enabled>
+                    </user:user>
+                    <user:user>
+                        <user:name>baseUser</user:name>
+                        <user:password>(removed)</user:password>
+                        <user:role>user</user:role>
+                        <user:enabled>true</user:enabled>
+                    </user:user>
+                </user:router>
+                <user:mode>moderate</user:mode>
+            </user:authority>
+        </user:config>
+    </data>
+</rpc-reply>


### PR DESCRIPTION
Previously, when a user was not authorized to access a resource, the resource would return with null fields. Now, the resource will return as an empty object (which eventually gets filtered out altogether).